### PR TITLE
dojo/8-jul/clementRoger/lvl-1/with-ai/try-1

### DIFF
--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -2,11 +2,9 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import * as request from 'supertest';
 import { AppModule } from './../src/app.module';
-import { GlobalFixtures } from './fixtures/global-fixtures';
 
 describe('AppController (e2e)', () => {
   let app: INestApplication;
-  let fixtures: GlobalFixtures;
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -23,14 +21,9 @@ describe('AppController (e2e)', () => {
     );
     app.setGlobalPrefix('api');
     await app.init();
-
-    // Initialize fixtures
-    fixtures = new GlobalFixtures(app);
-    await fixtures.load();
   });
 
   afterAll(async () => {
-    await fixtures.clear();
     await app.close();
   });
 

--- a/test/customer/customer-fixtures.ts
+++ b/test/customer/customer-fixtures.ts
@@ -1,0 +1,64 @@
+import { INestApplication } from '@nestjs/common';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Customer } from '../../src/entities/customer.entity';
+
+export class CustomerFixtures {
+  private app: INestApplication;
+  private customerRepository: Repository<Customer>;
+
+  // Cached fixtures for reuse across tests
+  private customers: Customer[] = [];
+
+  constructor(app: INestApplication) {
+    this.app = app;
+    this.customerRepository = app.get(getRepositoryToken(Customer));
+  }
+
+  async load(): Promise<void> {
+    // Clear existing data first
+    await this.clear();
+
+    // Create customers
+    this.customers = await this.createCustomers();
+  }
+
+  async clear(): Promise<void> {
+    // Delete in the correct order to respect foreign key constraints
+    await this.customerRepository.query('TRUNCATE TABLE "customers" CASCADE');
+    
+    // Reset cached data
+    this.customers = [];
+  }
+
+  // Helper methods to access fixture data
+  getCustomers(): Customer[] {
+    return this.customers;
+  }
+
+  // Customer creation
+  private async createCustomers(): Promise<Customer[]> {
+    const customers = [
+      this.customerRepository.create({
+        name: 'John Doe',
+        email: 'john@example.com',
+        phone: '123-456-7890',
+        address: '123 Main St',
+      }),
+      this.customerRepository.create({
+        name: 'Jane Smith',
+        email: 'jane@example.com',
+        phone: '987-654-3210',
+        address: '456 Oak Ave',
+      }),
+      this.customerRepository.create({
+        name: 'Bob Johnson',
+        email: 'bob@example.com',
+        phone: '555-555-5555',
+        address: '789 Pine Rd',
+      }),
+    ];
+    
+    return await this.customerRepository.save(customers);
+  }
+}

--- a/test/customer/customer.e2e-spec.ts
+++ b/test/customer/customer.e2e-spec.ts
@@ -2,13 +2,13 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import * as request from 'supertest';
 import { AppModule } from '../../src/app.module';
-import { GlobalFixtures } from '../fixtures/global-fixtures';
-import { CreateCustomerDto } from '../../src/customer/dto/create-customer.dto';
-import { UpdateCustomerDto } from '../../src/customer/dto/update-customer.dto';
+import { CustomerFixtures } from './customer-fixtures';
+import { CreateCustomerDto } from 'src/customer/dto/create-customer.dto';
+import { UpdateCustomerDto } from 'src/customer/dto/update-customer.dto';
 
 describe('CustomerController (e2e)', () => {
   let app: INestApplication;
-  let fixtures: GlobalFixtures;
+  let fixtures: CustomerFixtures;
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -27,7 +27,7 @@ describe('CustomerController (e2e)', () => {
     await app.init();
 
     // Initialize fixtures
-    fixtures = new GlobalFixtures(app);
+    fixtures = new CustomerFixtures(app);
     await fixtures.load();
   });
 

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -1,5 +1,9 @@
 {
-  "moduleFileExtensions": ["js", "json", "ts"],
+  "moduleFileExtensions": [
+    "js",
+    "json",
+    "ts"
+  ],
   "rootDir": ".",
   "testEnvironment": "node",
   "testRegex": ".e2e-spec.ts$",

--- a/test/loyalty/loyalty-fixtures.ts
+++ b/test/loyalty/loyalty-fixtures.ts
@@ -5,7 +5,7 @@ import { Customer } from '../../src/entities/customer.entity';
 import { Product } from '../../src/entities/product.entity';
 import { Order, OrderStatus } from '../../src/entities/order.entity';
 
-export class GlobalFixtures {
+export class LoyaltyFixtures {
   private app: INestApplication;
   private customerRepository: Repository<Customer>;
   private productRepository: Repository<Product>;
@@ -39,10 +39,10 @@ export class GlobalFixtures {
 
   async clear(): Promise<void> {
     // Delete in the correct order to respect foreign key constraints
-    await this.orderRepository.query('TRUNCATE TABLE order_products CASCADE');
-    await this.orderRepository.query('TRUNCATE TABLE orders CASCADE');
-    await this.productRepository.query('TRUNCATE TABLE products CASCADE');
-    await this.customerRepository.query('TRUNCATE TABLE customers CASCADE');
+    await this.orderRepository.query('TRUNCATE TABLE "order_products" CASCADE');
+    await this.orderRepository.query('TRUNCATE TABLE "orders" CASCADE');
+    await this.productRepository.query('TRUNCATE TABLE "products" CASCADE');
+    await this.customerRepository.query('TRUNCATE TABLE "customers" CASCADE');
     
     // Reset cached data
     this.customers = [];
@@ -77,12 +77,6 @@ export class GlobalFixtures {
         email: 'jane@example.com',
         phone: '987-654-3210',
         address: '456 Oak Ave',
-      }),
-      this.customerRepository.create({
-        name: 'Bob Johnson',
-        email: 'bob@example.com',
-        phone: '555-555-5555',
-        address: '789 Pine Rd',
       }),
     ];
     

--- a/test/loyalty/loyalty.e2e-spec.ts
+++ b/test/loyalty/loyalty.e2e-spec.ts
@@ -1,14 +1,14 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { INestApplication, ValidationPipe } from "@nestjs/common";
 import { AppModule } from "../../src/app.module";
-import { GlobalFixtures } from "../fixtures/global-fixtures";
+import { LoyaltyFixtures } from "./loyalty-fixtures";
 import { LoyaltyService } from "../../src/loyalty/loyalty.service";
 import { OrderService } from "../../src/order/order.service";
 import { CreateOrderDto } from "../../src/order/dto/create-order.dto";
 
 describe("LoyaltyService (e2e)", () => {
   let app: INestApplication;
-  let fixtures: GlobalFixtures;
+  let fixtures: LoyaltyFixtures;
   let loyaltyService: LoyaltyService;
   let orderService: OrderService;
 
@@ -28,7 +28,7 @@ describe("LoyaltyService (e2e)", () => {
     app.setGlobalPrefix("api");
     await app.init();
 
-    fixtures = new GlobalFixtures(app);
+    fixtures = new LoyaltyFixtures(app);
     await fixtures.load();
 
     loyaltyService = app.get(LoyaltyService);

--- a/test/order/order-fixtures.ts
+++ b/test/order/order-fixtures.ts
@@ -1,0 +1,132 @@
+import { INestApplication } from '@nestjs/common';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Customer } from '../../src/entities/customer.entity';
+import { Product } from '../../src/entities/product.entity';
+import { Order, OrderStatus } from '../../src/entities/order.entity';
+
+export class OrderFixtures {
+  private app: INestApplication;
+  private customerRepository: Repository<Customer>;
+  private productRepository: Repository<Product>;
+  private orderRepository: Repository<Order>;
+
+  // Cached fixtures for reuse across tests
+  private customers: Customer[] = [];
+  private products: Product[] = [];
+  private orders: Order[] = [];
+
+  constructor(app: INestApplication) {
+    this.app = app;
+    this.customerRepository = app.get(getRepositoryToken(Customer));
+    this.productRepository = app.get(getRepositoryToken(Product));
+    this.orderRepository = app.get(getRepositoryToken(Order));
+  }
+
+  async load(): Promise<void> {
+    // Clear existing data first
+    await this.clear();
+
+    // Create customers
+    this.customers = await this.createCustomers();
+    
+    // Create products
+    this.products = await this.createProducts();
+    
+    // Create orders
+    this.orders = await this.createOrders();
+  }
+
+  async clear(): Promise<void> {
+    // Delete in the correct order to respect foreign key constraints
+    await this.orderRepository.query('TRUNCATE TABLE "order_products" CASCADE');
+    await this.orderRepository.query('TRUNCATE TABLE "orders" CASCADE');
+    await this.productRepository.query('TRUNCATE TABLE "products" CASCADE');
+    await this.customerRepository.query('TRUNCATE TABLE "customers" CASCADE');
+    
+    // Reset cached data
+    this.customers = [];
+    this.products = [];
+    this.orders = [];
+  }
+
+  // Helper methods to access fixture data
+  getCustomers(): Customer[] {
+    return this.customers;
+  }
+
+  getProducts(): Product[] {
+    return this.products;
+  }
+
+  getOrders(): Order[] {
+    return this.orders;
+  }
+
+  // Customer creation
+  private async createCustomers(): Promise<Customer[]> {
+    const customers = [
+      this.customerRepository.create({
+        name: 'John Doe',
+        email: 'john@example.com',
+        phone: '123-456-7890',
+        address: '123 Main St',
+      }),
+      this.customerRepository.create({
+        name: 'Jane Smith',
+        email: 'jane@example.com',
+        phone: '987-654-3210',
+        address: '456 Oak Ave',
+      }),
+    ];
+    
+    return await this.customerRepository.save(customers);
+  }
+
+  // Product creation
+  private async createProducts(): Promise<Product[]> {
+    const products = [
+      this.productRepository.create({
+        name: 'Margherita Pizza',
+        description: 'Classic pizza with tomato sauce and mozzarella',
+        price: 12.99,
+        category: 'pizza',
+      }),
+      this.productRepository.create({
+        name: 'Pepperoni Pizza',
+        description: 'Pizza with tomato sauce, mozzarella, and pepperoni',
+        price: 14.99,
+        category: 'pizza',
+      }),
+    ];
+    
+    return await this.productRepository.save(products);
+  }
+
+  // Order creation
+  private async createOrders(): Promise<Order[]> {
+    const orders = [
+      this.orderRepository.create({
+        customer: this.customers[0],
+        products: [this.products[0]],
+        totalAmount: 12.99,
+        status: OrderStatus.DELIVERED,
+        notes: 'Extra cheese please',
+      }),
+      this.orderRepository.create({
+        customer: this.customers[1],
+        products: [this.products[1]],
+        totalAmount: 14.99,
+        status: OrderStatus.PREPARING,
+      }),
+      this.orderRepository.create({
+        customer: this.customers[0],
+        products: [this.products[0], this.products[1]],
+        totalAmount: 27.98,
+        status: OrderStatus.READY,
+      }),
+    ];
+    
+    return await this.orderRepository.save(orders);
+  }
+}

--- a/test/order/order.e2e-spec.ts
+++ b/test/order/order.e2e-spec.ts
@@ -2,13 +2,13 @@ import { Test, TestingModule } from "@nestjs/testing";
 import { INestApplication, ValidationPipe } from "@nestjs/common";
 import * as request from "supertest";
 import { AppModule } from "../../src/app.module";
-import { GlobalFixtures } from "../fixtures/global-fixtures";
+import { OrderFixtures } from "./order-fixtures";
 import { CreateOrderDto } from "../../src/order/dto/create-order.dto";
 import { OrderStatus } from "../../src/entities/order.entity";
 
 describe("OrderController (e2e)", () => {
   let app: INestApplication;
-  let fixtures: GlobalFixtures;
+  let fixtures: OrderFixtures;
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -27,7 +27,7 @@ describe("OrderController (e2e)", () => {
     await app.init();
 
     // Initialize fixtures
-    fixtures = new GlobalFixtures(app);
+    fixtures = new OrderFixtures(app);
     await fixtures.load();
   });
 

--- a/test/product/product-fixtures.ts
+++ b/test/product/product-fixtures.ts
@@ -1,0 +1,76 @@
+import { INestApplication } from '@nestjs/common';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Product } from '../../src/entities/product.entity';
+
+export class ProductFixtures {
+  private app: INestApplication;
+  private productRepository: Repository<Product>;
+
+  // Cached fixtures for reuse across tests
+  private products: Product[] = [];
+
+  constructor(app: INestApplication) {
+    this.app = app;
+    this.productRepository = app.get(getRepositoryToken(Product));
+  }
+
+  async load(): Promise<void> {
+    // Clear existing data first
+    await this.clear();
+
+    // Create products
+    this.products = await this.createProducts();
+  }
+
+  async clear(): Promise<void> {
+    // Delete in the correct order to respect foreign key constraints
+    await this.productRepository.query('TRUNCATE TABLE "products" CASCADE');
+    
+    // Reset cached data
+    this.products = [];
+  }
+
+  // Helper methods to access fixture data
+  getProducts(): Product[] {
+    return this.products;
+  }
+
+  // Product creation
+  private async createProducts(): Promise<Product[]> {
+    const products = [
+      this.productRepository.create({
+        name: 'Margherita Pizza',
+        description: 'Classic pizza with tomato sauce and mozzarella',
+        price: 12.99,
+        category: 'pizza',
+      }),
+      this.productRepository.create({
+        name: 'Pepperoni Pizza',
+        description: 'Pizza with tomato sauce, mozzarella, and pepperoni',
+        price: 14.99,
+        category: 'pizza',
+      }),
+      this.productRepository.create({
+        name: 'Caesar Salad',
+        description: 'Fresh salad with romaine lettuce, croutons, and Caesar dressing',
+        price: 8.99,
+        category: 'salad',
+      }),
+      this.productRepository.create({
+        name: 'Garlic Bread',
+        description: 'Toasted bread with garlic butter',
+        price: 4.99,
+        category: 'appetizer',
+      }),
+      this.productRepository.create({
+        name: 'Tiramisu',
+        description: 'Classic Italian dessert with coffee and mascarpone',
+        price: 7.99,
+        category: 'dessert',
+      }),
+    ];
+    
+    return await this.productRepository.save(products);
+  }
+}

--- a/test/product/product.e2e-spec.ts
+++ b/test/product/product.e2e-spec.ts
@@ -2,13 +2,13 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import * as request from 'supertest';
 import { AppModule } from '../../src/app.module';
-import { GlobalFixtures } from '../fixtures/global-fixtures';
-import { CreateProductDto } from '../../src/product/dto/create-product.dto';
-import { UpdateProductDto } from '../../src/product/dto/update-product.dto';
+import { ProductFixtures } from './product-fixtures';
+import { CreateProductDto } from 'src/product/dto/create-product.dto';
+import { UpdateProductDto } from 'src/product/dto/update-product.dto';
 
 describe('ProductController (e2e)', () => {
   let app: INestApplication;
-  let fixtures: GlobalFixtures;
+  let fixtures: ProductFixtures;
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -27,7 +27,7 @@ describe('ProductController (e2e)', () => {
     await app.init();
 
     // Initialize fixtures
-    fixtures = new GlobalFixtures(app);
+    fixtures = new ProductFixtures(app);
     await fixtures.load();
   });
 


### PR DESCRIPTION
with cline, with a gemini 3.5 api key :

currently, every tests use the global-fixtures.ts file to initialize the test environment. This is causing issues, because some new test may require a new fixture, which may break unrelated tests. I would like you to refactor the global-fixtures so that every test (customer, loyalty ...) uses its own instance of fixtures.

at one point i had to correct the model by telling it to only edit fixtures and not test contents