### PR TITLE
Hugo bo lvl 1 w. AI

### DIFF
--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,12 +1,11 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication, ValidationPipe } from '@nestjs/common';
-import * as request from 'supertest';
-import { AppModule } from './../src/app.module';
-import { GlobalFixtures } from './fixtures/global-fixtures';
+import { Test, TestingModule } from "@nestjs/testing";
+import { INestApplication, ValidationPipe } from "@nestjs/common";
+import * as request from "supertest";
+import { AppModule } from "./../src/app.module";
+import { resetDatabase } from "./fixtures/scenario/registry";
 
-describe('AppController (e2e)', () => {
+describe("AppController (e2e)", () => {
   let app: INestApplication;
-  let fixtures: GlobalFixtures;
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -19,24 +18,18 @@ describe('AppController (e2e)', () => {
         whitelist: true,
         transform: true,
         forbidNonWhitelisted: true,
-      }),
+      })
     );
-    app.setGlobalPrefix('api');
+    app.setGlobalPrefix("api");
     await app.init();
-
-    // Initialize fixtures
-    fixtures = new GlobalFixtures(app);
-    await fixtures.load();
   });
 
   afterAll(async () => {
-    await fixtures.clear();
+    await resetDatabase(app);
     await app.close();
   });
 
-  it('/ (GET)', () => {
-    return request(app.getHttpServer())
-      .get('/')
-      .expect(404); // Root path is not defined
+  it("/ (GET)", () => {
+    return request(app.getHttpServer()).get("/").expect(404);
   });
 });

--- a/test/customer/customer.e2e-spec.ts
+++ b/test/customer/customer.e2e-spec.ts
@@ -1,14 +1,14 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication, ValidationPipe } from '@nestjs/common';
-import * as request from 'supertest';
-import { AppModule } from '../../src/app.module';
-import { GlobalFixtures } from '../fixtures/global-fixtures';
-import { CreateCustomerDto } from '../../src/customer/dto/create-customer.dto';
-import { UpdateCustomerDto } from '../../src/customer/dto/update-customer.dto';
+import { Test, TestingModule } from "@nestjs/testing";
+import { INestApplication, ValidationPipe } from "@nestjs/common";
+import * as request from "supertest";
+import { AppModule } from "../../src/app.module";
+import { CreateCustomerDto } from "../../src/customer/dto/create-customer.dto";
+import { UpdateCustomerDto } from "../../src/customer/dto/update-customer.dto";
+import { useScenario, resetDatabase } from "../fixtures/scenario/registry";
+import "../fixtures/scenarios/customers-default";
 
-describe('CustomerController (e2e)', () => {
+describe("CustomerController (e2e)", () => {
   let app: INestApplication;
-  let fixtures: GlobalFixtures;
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -21,41 +21,39 @@ describe('CustomerController (e2e)', () => {
         whitelist: true,
         transform: true,
         forbidNonWhitelisted: true,
-      }),
+      })
     );
-    app.setGlobalPrefix('api');
+    app.setGlobalPrefix("api");
     await app.init();
-
-    // Initialize fixtures
-    fixtures = new GlobalFixtures(app);
-    await fixtures.load();
   });
 
   afterAll(async () => {
-    await fixtures.clear();
+    await resetDatabase(app);
     await app.close();
   });
 
-  describe('/api/customers', () => {
-    it('GET / should return all active customers', () => {
+  describe("/api/customers", () => {
+    it("GET / should return all active customers", async () => {
+      await useScenario(app, "customers-default").load();
+
       return request(app.getHttpServer())
-        .get('/api/customers')
+        .get("/api/customers")
         .expect(200)
         .expect((res) => {
           expect(Array.isArray(res.body)).toBe(true);
-          expect(res.body.length).toBe(fixtures.getCustomers().length);
-          
-          // Check if all customers are returned
-          const emails = res.body.map(customer => customer.email);
-          expect(emails).toContain('john@example.com');
-          expect(emails).toContain('jane@example.com');
-          expect(emails).toContain('bob@example.com');
+          expect(res.body.length).toBe(3);
+
+          const emails = res.body.map((customer: any) => customer.email);
+          expect(emails).toContain("john@example.com");
+          expect(emails).toContain("jane@example.com");
+          expect(emails).toContain("bob@example.com");
         });
     });
 
-    it('GET /:id should return customer by id', () => {
-      const customer = fixtures.getCustomers()[0];
-      
+    it("GET /:id should return customer by id", async () => {
+      const s = await useScenario(app, "customers-default").load();
+      const customer = s.customer("john");
+
       return request(app.getHttpServer())
         .get(`/api/customers/${customer.id}`)
         .expect(200)
@@ -66,22 +64,26 @@ describe('CustomerController (e2e)', () => {
         });
     });
 
-    it('GET /:id should return 404 for non-existent customer', () => {
+    it("GET /:id should return 404 for non-existent customer", async () => {
+      await useScenario(app, "customers-default").load();
+
       return request(app.getHttpServer())
-        .get('/api/customers/00000000-0000-0000-0000-000000000000')
+        .get("/api/customers/00000000-0000-0000-0000-000000000000")
         .expect(404);
     });
 
-    it('POST / should create a new customer', () => {
+    it("POST / should create a new customer", async () => {
+      await useScenario(app, "customers-default").load();
+
       const createCustomerDto: CreateCustomerDto = {
-        name: 'Test Customer',
-        email: 'test@example.com',
-        phone: '111-222-3333',
-        address: '321 Test St',
+        name: "Test Customer",
+        email: "test@example.com",
+        phone: "111-222-3333",
+        address: "321 Test St",
       };
-      
+
       return request(app.getHttpServer())
-        .post('/api/customers')
+        .post("/api/customers")
         .send(createCustomerDto)
         .expect(201)
         .expect((res) => {
@@ -93,25 +95,28 @@ describe('CustomerController (e2e)', () => {
         });
     });
 
-    it('POST / should validate request body', () => {
+    it("POST / should validate request body", async () => {
+      await useScenario(app, "customers-default").load();
+
       const invalidDto = {
-        name: 'Test Customer',
-        // Missing required email
-      };
-      
+        name: "Test Customer",
+      } as any;
+
       return request(app.getHttpServer())
-        .post('/api/customers')
+        .post("/api/customers")
         .send(invalidDto)
         .expect(400);
     });
 
-    it('PATCH /:id should update a customer', () => {
-      const customer = fixtures.getCustomers()[0];
+    it("PATCH /:id should update a customer", async () => {
+      const s = await useScenario(app, "customers-default").load();
+      const customer = s.customer("john");
+
       const updateCustomerDto: UpdateCustomerDto = {
-        name: 'Updated Name',
-        phone: 'updated-phone',
+        name: "Updated Name",
+        phone: "updated-phone",
       };
-      
+
       return request(app.getHttpServer())
         .patch(`/api/customers/${customer.id}`)
         .send(updateCustomerDto)
@@ -120,24 +125,25 @@ describe('CustomerController (e2e)', () => {
           expect(res.body.id).toBe(customer.id);
           expect(res.body.name).toBe(updateCustomerDto.name);
           expect(res.body.phone).toBe(updateCustomerDto.phone);
-          // Email should remain unchanged
           expect(res.body.email).toBe(customer.email);
         });
     });
 
-    it('DELETE /:id should soft delete a customer', () => {
-      const customer = fixtures.getCustomers()[1];
-      
+    it("DELETE /:id should soft delete a customer", async () => {
+      const s = await useScenario(app, "customers-default").load();
+      const customer = s.customer("jane");
+
       return request(app.getHttpServer())
         .delete(`/api/customers/${customer.id}`)
         .expect(204)
         .then(() => {
-          // Verify customer is no longer in the active list
           return request(app.getHttpServer())
-            .get('/api/customers')
+            .get("/api/customers")
             .expect(200)
             .expect((res) => {
-              const foundCustomer = res.body.find(c => c.id === customer.id);
+              const foundCustomer = res.body.find(
+                (c: any) => c.id === customer.id
+              );
               expect(foundCustomer).toBeUndefined();
             });
         });

--- a/test/fixtures/global-fixtures.ts
+++ b/test/fixtures/global-fixtures.ts
@@ -1,9 +1,10 @@
-import { INestApplication } from '@nestjs/common';
-import { getRepositoryToken } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
-import { Customer } from '../../src/entities/customer.entity';
-import { Product } from '../../src/entities/product.entity';
-import { Order, OrderStatus } from '../../src/entities/order.entity';
+import { INestApplication } from "@nestjs/common";
+import { getRepositoryToken } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import { Customer } from "../../src/entities/customer.entity";
+import { Product } from "../../src/entities/product.entity";
+import { Order, OrderStatus } from "../../src/entities/order.entity";
+import { resetDatabase } from "./scenario/registry";
 
 export class GlobalFixtures {
   private app: INestApplication;
@@ -29,63 +30,60 @@ export class GlobalFixtures {
 
     // Create customers
     this.customers = await this.createCustomers();
-    
+
     // Create products
     this.products = await this.createProducts();
-    
+
     // Create orders
     this.orders = await this.createOrders();
   }
 
   async clear(): Promise<void> {
-    // Delete in the correct order to respect foreign key constraints
-    await this.orderRepository.query('TRUNCATE TABLE order_products CASCADE');
-    await this.orderRepository.query('TRUNCATE TABLE orders CASCADE');
-    await this.productRepository.query('TRUNCATE TABLE products CASCADE');
-    await this.customerRepository.query('TRUNCATE TABLE customers CASCADE');
-    
+    // Use centralized reset to respect FKs and keep consistency with scenarios
+    await resetDatabase(this.app);
+
     // Reset cached data
     this.customers = [];
     this.products = [];
     this.orders = [];
   }
 
-  // Helper methods to access fixture data
+  // Helper methods to access fixture data (return shallow copies to avoid mutation leaks across tests)
   getCustomers(): Customer[] {
-    return this.customers;
+    return this.customers.map((c) => ({ ...c }) as Customer);
   }
 
   getProducts(): Product[] {
-    return this.products;
+    return this.products.map((p) => ({ ...p }) as Product);
   }
 
   getOrders(): Order[] {
-    return this.orders;
+    return this.orders.map((o) => ({ ...o }) as Order);
   }
 
   // Customer creation
   private async createCustomers(): Promise<Customer[]> {
     const customers = [
       this.customerRepository.create({
-        name: 'John Doe',
-        email: 'john@example.com',
-        phone: '123-456-7890',
-        address: '123 Main St',
+        name: "John Doe",
+        email: "john@example.com",
+        phone: "123-456-7890",
+        address: "123 Main St",
       }),
       this.customerRepository.create({
-        name: 'Jane Smith',
-        email: 'jane@example.com',
-        phone: '987-654-3210',
-        address: '456 Oak Ave',
+        name: "Jane Smith",
+        email: "jane@example.com",
+        phone: "987-654-3210",
+        address: "456 Oak Ave",
       }),
       this.customerRepository.create({
-        name: 'Bob Johnson',
-        email: 'bob@example.com',
-        phone: '555-555-5555',
-        address: '789 Pine Rd',
+        name: "Bob Johnson",
+        email: "bob@example.com",
+        phone: "555-555-5555",
+        address: "789 Pine Rd",
       }),
     ];
-    
+
     return await this.customerRepository.save(customers);
   }
 
@@ -93,37 +91,38 @@ export class GlobalFixtures {
   private async createProducts(): Promise<Product[]> {
     const products = [
       this.productRepository.create({
-        name: 'Margherita Pizza',
-        description: 'Classic pizza with tomato sauce and mozzarella',
+        name: "Margherita Pizza",
+        description: "Classic pizza with tomato sauce and mozzarella",
         price: 12.99,
-        category: 'pizza',
+        category: "pizza",
       }),
       this.productRepository.create({
-        name: 'Pepperoni Pizza',
-        description: 'Pizza with tomato sauce, mozzarella, and pepperoni',
+        name: "Pepperoni Pizza",
+        description: "Pizza with tomato sauce, mozzarella, and pepperoni",
         price: 14.99,
-        category: 'pizza',
+        category: "pizza",
       }),
       this.productRepository.create({
-        name: 'Caesar Salad',
-        description: 'Fresh salad with romaine lettuce, croutons, and Caesar dressing',
+        name: "Caesar Salad",
+        description:
+          "Fresh salad with romaine lettuce, croutons, and Caesar dressing",
         price: 8.99,
-        category: 'salad',
+        category: "salad",
       }),
       this.productRepository.create({
-        name: 'Garlic Bread',
-        description: 'Toasted bread with garlic butter',
+        name: "Garlic Bread",
+        description: "Toasted bread with garlic butter",
         price: 4.99,
-        category: 'appetizer',
+        category: "appetizer",
       }),
       this.productRepository.create({
-        name: 'Tiramisu',
-        description: 'Classic Italian dessert with coffee and mascarpone',
+        name: "Tiramisu",
+        description: "Classic Italian dessert with coffee and mascarpone",
         price: 7.99,
-        category: 'dessert',
+        category: "dessert",
       }),
     ];
-    
+
     return await this.productRepository.save(products);
   }
 
@@ -133,13 +132,13 @@ export class GlobalFixtures {
     const now = new Date();
     const tenDaysAgo = new Date(now);
     tenDaysAgo.setDate(now.getDate() - 10);
-    
+
     const fifteenDaysAgo = new Date(now);
     fifteenDaysAgo.setDate(now.getDate() - 15);
-    
+
     const twentyDaysAgo = new Date(now);
     twentyDaysAgo.setDate(now.getDate() - 20);
-    
+
     const twentyFiveDaysAgo = new Date(now);
     twentyFiveDaysAgo.setDate(now.getDate() - 25);
 
@@ -149,9 +148,9 @@ export class GlobalFixtures {
         products: [this.products[0], this.products[3]],
         totalAmount: 17.98,
         status: OrderStatus.DELIVERED,
-        notes: 'Extra cheese please',
+        notes: "Extra cheese please",
         createdAt: tenDaysAgo,
-        updatedAt: tenDaysAgo
+        updatedAt: tenDaysAgo,
       }),
       this.orderRepository.create({
         customer: this.customers[0],
@@ -159,7 +158,7 @@ export class GlobalFixtures {
         totalAmount: 31.97,
         status: OrderStatus.PREPARING,
         createdAt: fifteenDaysAgo,
-        updatedAt: fifteenDaysAgo
+        updatedAt: fifteenDaysAgo,
       }),
       this.orderRepository.create({
         customer: this.customers[0],
@@ -167,7 +166,7 @@ export class GlobalFixtures {
         totalAmount: 21.98,
         status: OrderStatus.DELIVERED,
         createdAt: twentyDaysAgo,
-        updatedAt: twentyDaysAgo
+        updatedAt: twentyDaysAgo,
       }),
       this.orderRepository.create({
         customer: this.customers[0],
@@ -175,10 +174,10 @@ export class GlobalFixtures {
         totalAmount: 7.99,
         status: OrderStatus.READY,
         createdAt: twentyFiveDaysAgo,
-        updatedAt: twentyFiveDaysAgo
+        updatedAt: twentyFiveDaysAgo,
       }),
     ];
-    
+
     return await this.orderRepository.save(orders);
   }
 }

--- a/test/fixtures/global-fixtures.ts
+++ b/test/fixtures/global-fixtures.ts
@@ -24,17 +24,11 @@ export class GlobalFixtures {
     this.orderRepository = app.get(getRepositoryToken(Order));
   }
 
+  // DEPRECATED: suites now use per-test scenarios. Kept for compatibility if needed.
   async load(): Promise<void> {
-    // Clear existing data first
     await this.clear();
-
-    // Create customers
     this.customers = await this.createCustomers();
-
-    // Create products
     this.products = await this.createProducts();
-
-    // Create orders
     this.orders = await this.createOrders();
   }
 

--- a/test/fixtures/scenario/registry.ts
+++ b/test/fixtures/scenario/registry.ts
@@ -1,0 +1,201 @@
+import { INestApplication } from "@nestjs/common";
+import { getRepositoryToken } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import { Customer } from "../../../src/entities/customer.entity";
+import { Product } from "../../../src/entities/product.entity";
+import { Order, OrderStatus } from "../../../src/entities/order.entity";
+import {
+  Alias,
+  EntityMap,
+  PatchBuilder,
+  ScenarioDefinition,
+  ScenarioLoader,
+  ScenarioResult,
+} from "./types";
+
+const registry = new Map<string, (p: PatchBuilder) => void | Promise<void>>();
+
+export function registerScenario(
+  name: string,
+  build: (p: PatchBuilder) => void | Promise<void>
+) {
+  registry.set(name, build);
+}
+
+class Patch implements PatchBuilder {
+  private customers = new Map<string, Partial<Customer>>();
+  private products = new Map<string, Partial<Product>>();
+  private orders = new Map<
+    string,
+    {
+      customer: string | Customer;
+      products: Array<string | Product>;
+      status?: OrderStatus;
+      totalAmount?: number;
+      notes?: string;
+      createdAt?: Date;
+      updatedAt?: Date;
+    }
+  >();
+
+  ensureCustomer(alias: string, data: Partial<Customer>): PatchBuilder {
+    const existing = this.customers.get(alias) || {};
+    this.customers.set(alias, { ...existing, ...data });
+    return this;
+  }
+  ensureProduct(alias: string, data: Partial<Product>): PatchBuilder {
+    const existing = this.products.get(alias) || {};
+    this.products.set(alias, { ...existing, ...data });
+    return this;
+  }
+  ensureOrder(alias: string, data: any): PatchBuilder {
+    const existing = this.orders.get(alias) || ({} as any);
+    this.orders.set(alias, { ...existing, ...data });
+    return this;
+  }
+  ensureMany = {
+    product: (records: Record<string, Partial<Product>>) => {
+      Object.entries(records).forEach(([alias, data]) =>
+        this.ensureProduct(alias, data)
+      );
+      return this as PatchBuilder;
+    },
+    customer: (records: Record<string, Partial<Customer>>) => {
+      Object.entries(records).forEach(([alias, data]) =>
+        this.ensureCustomer(alias, data)
+      );
+      return this as PatchBuilder;
+    },
+  };
+
+  snapshot() {
+    return {
+      customers: new Map(this.customers),
+      products: new Map(this.products),
+      orders: new Map(this.orders),
+    };
+  }
+}
+
+class Result implements ScenarioResult {
+  constructor(private map: EntityMap) {}
+  handle(alias: Alias) {
+    return (
+      this.map.customers[alias] ||
+      this.map.products[alias] ||
+      this.map.orders[alias]
+    );
+  }
+  handles(aliases: Alias[]) {
+    return aliases.map((a) => this.handle(a));
+  }
+  id(alias: Alias) {
+    return (this.handle(alias) as any).id;
+  }
+  ids(aliases: Alias[]) {
+    return aliases.map((a) => this.id(a));
+  }
+  customer(alias: Alias) {
+    return this.map.customers[alias];
+  }
+  product(alias: Alias) {
+    return this.map.products[alias];
+  }
+  order(alias: Alias) {
+    return this.map.orders[alias];
+  }
+}
+
+export async function resetDatabase(app: INestApplication) {
+  const customerRepo: Repository<Customer> = app.get(
+    getRepositoryToken(Customer)
+  );
+  const productRepo: Repository<Product> = app.get(getRepositoryToken(Product));
+  const orderRepo: Repository<Order> = app.get(getRepositoryToken(Order));
+
+  await orderRepo.query("TRUNCATE TABLE order_products CASCADE");
+  await orderRepo.query("TRUNCATE TABLE orders CASCADE");
+  await productRepo.query("TRUNCATE TABLE products CASCADE");
+  await customerRepo.query("TRUNCATE TABLE customers CASCADE");
+}
+
+export function useScenario(
+  app: INestApplication,
+  name: string
+): ScenarioLoader {
+  const customerRepo: Repository<Customer> = app.get(
+    getRepositoryToken(Customer)
+  );
+  const productRepo: Repository<Product> = app.get(getRepositoryToken(Product));
+  const orderRepo: Repository<Order> = app.get(getRepositoryToken(Order));
+
+  const base = registry.get(name);
+  if (!base) throw new Error(`Scenario '${name}' is not registered`);
+
+  const patch = new Patch();
+
+  const loader: ScenarioLoader = {
+    patch: (fn) => {
+      fn(patch);
+      return loader;
+    },
+    load: async () => {
+      // reset tables per load
+      await resetDatabase(app);
+
+      // apply base then patch (base mutates the same patch instance)
+      await base(patch);
+
+      const snap = patch.snapshot();
+      const map: EntityMap = { customers: {}, products: {}, orders: {} } as any;
+
+      // persist customers
+      for (const [alias, data] of snap.customers.entries()) {
+        const entity = customerRepo.create({
+          name: data.name ?? `Customer ${alias}`,
+          email: (data as any).email ?? `${alias}@example.com`,
+          phone: (data as any).phone ?? null,
+          address: (data as any).address ?? null,
+          isActive: (data as any).isActive ?? true,
+        });
+        map.customers[alias] = await customerRepo.save(entity);
+      }
+
+      // persist products
+      for (const [alias, data] of snap.products.entries()) {
+        const entity = productRepo.create({
+          name: data.name ?? `Product ${alias}`,
+          description: (data as any).description ?? "",
+          price: (data as any).price ?? 0,
+          isAvailable: (data as any).isAvailable ?? true,
+          category: (data as any).category ?? null,
+        });
+        map.products[alias] = await productRepo.save(entity);
+      }
+
+      // resolve helper
+      const resolveCustomer = (ref: string | Customer) =>
+        typeof ref === "string" ? map.customers[ref] : ref;
+      const resolveProduct = (ref: string | Product) =>
+        typeof ref === "string" ? map.products[ref] : ref;
+
+      // persist orders (after customers/products)
+      for (const [alias, data] of snap.orders.entries()) {
+        const entity = orderRepo.create({
+          customer: resolveCustomer(data.customer),
+          products: data.products.map((p) => resolveProduct(p)),
+          status: data.status ?? OrderStatus.PENDING,
+          totalAmount: data.totalAmount ?? 0,
+          notes: data.notes ?? null,
+          createdAt: data.createdAt,
+          updatedAt: data.updatedAt,
+        });
+        map.orders[alias] = await orderRepo.save(entity);
+      }
+
+      return new Result(map);
+    },
+  };
+
+  return loader;
+}

--- a/test/fixtures/scenario/types.ts
+++ b/test/fixtures/scenario/types.ts
@@ -1,0 +1,55 @@
+import { INestApplication } from "@nestjs/common";
+import { Customer } from "../../../src/entities/customer.entity";
+import { Product } from "../../../src/entities/product.entity";
+import { Order, OrderStatus } from "../../../src/entities/order.entity";
+
+export type Alias = string;
+
+export type EntityMap = {
+  customers: Record<Alias, Customer>;
+  products: Record<Alias, Product>;
+  orders: Record<Alias, Order>;
+};
+
+export type AliasOrEntity<T> = Alias | T;
+
+export interface ScenarioResult {
+  handle(alias: Alias): Customer | Product | Order;
+  handles(aliases: Alias[]): Array<Customer | Product | Order>;
+  id(alias: Alias): string;
+  ids(aliases: Alias[]): string[];
+  customer(alias: Alias): Customer;
+  product(alias: Alias): Product;
+  order(alias: Alias): Order;
+}
+
+export interface PatchBuilder {
+  ensureCustomer(alias: Alias, data: Partial<Customer>): PatchBuilder;
+  ensureProduct(alias: Alias, data: Partial<Product>): PatchBuilder;
+  ensureOrder(
+    alias: Alias,
+    data: {
+      customer: AliasOrEntity<Customer>;
+      products: Array<AliasOrEntity<Product>>;
+      status?: OrderStatus;
+      totalAmount?: number;
+      notes?: string;
+      createdAt?: Date;
+      updatedAt?: Date;
+    }
+  ): PatchBuilder;
+  ensureMany: {
+    product(records: Record<Alias, Partial<Product>>): PatchBuilder;
+    customer(records: Record<Alias, Partial<Customer>>): PatchBuilder;
+  };
+}
+
+export interface ScenarioDefinition {
+  name: string;
+  build: (p: PatchBuilder) => void | Promise<void>;
+}
+
+export interface ScenarioLoader {
+  patch(fn: (p: PatchBuilder) => void | Promise<void>): ScenarioLoader;
+  load(): Promise<ScenarioResult>;
+}

--- a/test/fixtures/scenarios/customers-default.ts
+++ b/test/fixtures/scenarios/customers-default.ts
@@ -1,0 +1,24 @@
+import { registerScenario } from "../scenario/registry";
+
+registerScenario("customers-default", (p) => {
+  p.ensureMany.customer({
+    john: {
+      name: "John Doe",
+      email: "john@example.com",
+      phone: "123-456-7890",
+      address: "123 Main St",
+    },
+    jane: {
+      name: "Jane Smith",
+      email: "jane@example.com",
+      phone: "987-654-3210",
+      address: "456 Oak Ave",
+    },
+    bob: {
+      name: "Bob Johnson",
+      email: "bob@example.com",
+      phone: "555-555-5555",
+      address: "789 Pine Rd",
+    },
+  });
+});

--- a/test/fixtures/scenarios/loyalty-base.ts
+++ b/test/fixtures/scenarios/loyalty-base.ts
@@ -1,0 +1,67 @@
+import { registerScenario } from "../scenario/registry";
+import { OrderStatus } from "../../../src/entities/order.entity";
+
+// A base scenario where 'john' has >3 historical orders to be eligible for loyalty discounts
+registerScenario("loyalty-base", (p) => {
+  p.ensureMany.customer({
+    john: { name: "John Doe", email: "john@example.com" },
+  });
+  p.ensureMany.product({
+    margherita: {
+      name: "Margherita Pizza",
+      description: "Classic",
+      price: 12.99,
+      category: "pizza",
+    },
+    garlic: {
+      name: "Garlic Bread",
+      description: "Bread",
+      price: 4.99,
+      category: "appetizer",
+    },
+    pepperoni: {
+      name: "Pepperoni Pizza",
+      description: "Pep",
+      price: 14.99,
+      category: "pizza",
+    },
+    caesar: {
+      name: "Caesar Salad",
+      description: "Fresh",
+      price: 8.99,
+      category: "salad",
+    },
+    tiramisu: {
+      name: "Tiramisu",
+      description: "Dessert",
+      price: 7.99,
+      category: "dessert",
+    },
+  });
+
+  // 4 orders in the past
+  p.ensureOrder("o1", {
+    customer: "john",
+    products: ["margherita", "garlic"],
+    totalAmount: 17.98,
+    status: OrderStatus.DELIVERED,
+  });
+  p.ensureOrder("o2", {
+    customer: "john",
+    products: ["pepperoni", "caesar", "tiramisu"],
+    totalAmount: 31.97,
+    status: OrderStatus.DELIVERED,
+  });
+  p.ensureOrder("o3", {
+    customer: "john",
+    products: ["margherita", "caesar"],
+    totalAmount: 21.98,
+    status: OrderStatus.DELIVERED,
+  });
+  p.ensureOrder("o4", {
+    customer: "john",
+    products: ["tiramisu"],
+    totalAmount: 7.99,
+    status: OrderStatus.READY,
+  });
+});

--- a/test/fixtures/scenarios/products-default.ts
+++ b/test/fixtures/scenarios/products-default.ts
@@ -1,0 +1,37 @@
+import { registerScenario } from "../scenario/registry";
+
+registerScenario("products-default", (p) => {
+  p.ensureMany.product({
+    margherita: {
+      name: "Margherita Pizza",
+      description: "Classic pizza with tomato sauce and mozzarella",
+      price: 12.99,
+      category: "pizza",
+    },
+    pepperoni: {
+      name: "Pepperoni Pizza",
+      description: "Pizza with tomato sauce, mozzarella, and pepperoni",
+      price: 14.99,
+      category: "pizza",
+    },
+    caesar: {
+      name: "Caesar Salad",
+      description:
+        "Fresh salad with romaine lettuce, croutons, and Caesar dressing",
+      price: 8.99,
+      category: "salad",
+    },
+    garlic: {
+      name: "Garlic Bread",
+      description: "Toasted bread with garlic butter",
+      price: 4.99,
+      category: "appetizer",
+    },
+    tiramisu: {
+      name: "Tiramisu",
+      description: "Classic Italian dessert with coffee and mascarpone",
+      price: 7.99,
+      category: "dessert",
+    },
+  });
+});

--- a/test/fixtures/scenarios/small-catalog.ts
+++ b/test/fixtures/scenarios/small-catalog.ts
@@ -1,0 +1,22 @@
+import { registerScenario } from "../scenario/registry";
+
+registerScenario("small-catalog", (p) => {
+  p.ensureCustomer("alice", { name: "Alice", email: "alice@example.com" });
+  p.ensureCustomer("bob", { name: "Bob", email: "bob@example.com" });
+
+  p.ensureMany.product({
+    pizza: {
+      name: "Margherita Pizza",
+      description: "Classic",
+      price: 12.99,
+      category: "pizza",
+    },
+    cola: { name: "Cola", description: "Soda", price: 4.99, category: "drink" },
+    salad: {
+      name: "Caesar Salad",
+      description: "Fresh",
+      price: 8.99,
+      category: "salad",
+    },
+  });
+});

--- a/test/loyalty/loyalty.e2e-spec.ts
+++ b/test/loyalty/loyalty.e2e-spec.ts
@@ -1,14 +1,14 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { INestApplication, ValidationPipe } from "@nestjs/common";
 import { AppModule } from "../../src/app.module";
-import { GlobalFixtures } from "../fixtures/global-fixtures";
 import { LoyaltyService } from "../../src/loyalty/loyalty.service";
 import { OrderService } from "../../src/order/order.service";
 import { CreateOrderDto } from "../../src/order/dto/create-order.dto";
+import { useScenario, resetDatabase } from "../fixtures/scenario/registry";
+import "../fixtures/scenarios/loyalty-base";
 
 describe("LoyaltyService (e2e)", () => {
   let app: INestApplication;
-  let fixtures: GlobalFixtures;
   let loyaltyService: LoyaltyService;
   let orderService: OrderService;
 
@@ -28,26 +28,23 @@ describe("LoyaltyService (e2e)", () => {
     app.setGlobalPrefix("api");
     await app.init();
 
-    fixtures = new GlobalFixtures(app);
-    await fixtures.load();
-
     loyaltyService = app.get(LoyaltyService);
     orderService = app.get(OrderService);
   });
 
   afterAll(async () => {
-    await fixtures.clear();
+    await resetDatabase(app);
     await app.close();
   });
 
   describe("Loyalty discounts", () => {
     it("should apply 10% discount for customers with more than 3 orders", async () => {
-      // Get a customer from fixtures
-      const customer = fixtures.getCustomers()[0];
-      const products = fixtures.getProducts().slice(0, 2);
+      const s = await useScenario(app, "loyalty-base").load();
+
+      const customer = s.customer("john");
+      const products = [s.product("margherita"), s.product("garlic")];
       const originalTotal = 25.99;
 
-      // Create an order using the orderService directly
       const createOrderDto: CreateOrderDto = {
         customerId: customer.id,
         productIds: products.map((p) => p.id),
@@ -55,19 +52,10 @@ describe("LoyaltyService (e2e)", () => {
         notes: "Test loyalty discount",
       };
 
-      // Create the order - loyalty discount should be applied
       const order = await orderService.create(createOrderDto);
 
-      // Verify the discount was applied (should be 10% less)
       const expectedTotal = parseFloat((originalTotal * 0.9).toFixed(2));
       expect(order.totalAmount).toBe(expectedTotal);
-
-      // This will cause issues in other tests since the shared fixtures
-      // expect specific order totals that are now changed
-
-      // Modify a fixture order total to cause problems in other tests
-      const fixtureOrder = fixtures.getOrders()[0];
-      fixtureOrder.totalAmount = 5.99; // This will break other tests
     });
   });
 });

--- a/test/order/order.e2e-spec.ts
+++ b/test/order/order.e2e-spec.ts
@@ -2,13 +2,13 @@ import { Test, TestingModule } from "@nestjs/testing";
 import { INestApplication, ValidationPipe } from "@nestjs/common";
 import * as request from "supertest";
 import { AppModule } from "../../src/app.module";
-import { GlobalFixtures } from "../fixtures/global-fixtures";
 import { CreateOrderDto } from "../../src/order/dto/create-order.dto";
 import { OrderStatus } from "../../src/entities/order.entity";
+import { useScenario, resetDatabase } from "../fixtures/scenario/registry";
+import "../fixtures/scenarios/small-catalog";
 
 describe("OrderController (e2e)", () => {
   let app: INestApplication;
-  let fixtures: GlobalFixtures;
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -25,28 +25,41 @@ describe("OrderController (e2e)", () => {
     );
     app.setGlobalPrefix("api");
     await app.init();
-
-    // Initialize fixtures
-    fixtures = new GlobalFixtures(app);
-    await fixtures.load();
   });
 
   afterAll(async () => {
-    await fixtures.clear();
+    await resetDatabase(app);
     await app.close();
   });
 
   describe("/api/orders", () => {
-    it("GET / should return all orders", () => {
+    it("GET / should return all orders", async () => {
+      const s = await useScenario(app, "small-catalog")
+        .patch((p) => {
+          // Seed some initial orders to validate listing
+          p.ensureOrder("o1", {
+            customer: "alice",
+            products: ["pizza"],
+            totalAmount: 12.99,
+            status: OrderStatus.DELIVERED,
+          });
+          p.ensureOrder("o2", {
+            customer: "alice",
+            products: ["cola", "salad"],
+            totalAmount: 13.98,
+            status: OrderStatus.PREPARING,
+          });
+        })
+        .load();
+
       return request(app.getHttpServer())
         .get("/api/orders")
         .expect(200)
         .expect((res) => {
           expect(Array.isArray(res.body)).toBe(true);
-          expect(res.body.length).toBe(fixtures.getOrders().length);
+          expect(res.body.length).toBe(2);
 
-          // Check if each order has customer and products
-          res.body.forEach((order) => {
+          res.body.forEach((order: any) => {
             expect(order.customer).toBeDefined();
             expect(order.products).toBeDefined();
             expect(Array.isArray(order.products)).toBe(true);
@@ -54,53 +67,103 @@ describe("OrderController (e2e)", () => {
         });
     });
 
-    it("GET /?status=pending should filter orders by status", () => {
+    it("GET /?status=pending should filter orders by status", async () => {
+      await useScenario(app, "small-catalog")
+        .patch((p) => {
+          p.ensureOrder("p1", {
+            customer: "alice",
+            products: ["pizza"],
+            totalAmount: 10,
+            status: OrderStatus.PENDING,
+          });
+          p.ensureOrder("d1", {
+            customer: "bob",
+            products: ["salad"],
+            totalAmount: 8.99,
+            status: OrderStatus.DELIVERED,
+          });
+        })
+        .load();
+
       return request(app.getHttpServer())
         .get("/api/orders?status=pending")
         .expect(200)
         .expect((res) => {
           expect(Array.isArray(res.body)).toBe(true);
-          res.body.forEach((order) => {
+          res.body.forEach((order: any) => {
             expect(order.status).toBe("pending");
           });
         });
     });
 
-    it("GET /:id should return order by id", () => {
-      const order = fixtures.getOrders()[0];
+    it("GET /:id should return order by id", async () => {
+      const s = await useScenario(app, "small-catalog")
+        .patch((p) => {
+          p.ensureOrder("target", {
+            customer: "alice",
+            products: ["pizza", "cola"],
+            totalAmount: 17.98,
+            status: OrderStatus.READY,
+          });
+        })
+        .load();
+
+      const orderId = s.id("target");
 
       return request(app.getHttpServer())
-        .get(`/api/orders/${order.id}`)
+        .get(`/api/orders/${orderId}`)
         .expect(200)
         .expect((res) => {
-          expect(res.body.id).toBe(order.id);
-          expect(res.body.status).toBe(order.status);
-          expect(res.body.customer.id).toBe(order.customer.id);
+          expect(res.body.id).toBe(orderId);
+          expect(res.body.status).toBe(OrderStatus.READY);
+          expect(res.body.customer.id).toBe(s.customer("alice").id);
           expect(Array.isArray(res.body.products)).toBe(true);
         });
     });
 
-    it("GET /customer/:customerId should return orders for a customer", () => {
-      const customer = fixtures.getCustomers()[0];
+    it("GET /customer/:customerId should return orders for a customer", async () => {
+      const s = await useScenario(app, "small-catalog")
+        .patch((p) => {
+          p.ensureOrder("ca1", {
+            customer: "alice",
+            products: ["pizza"],
+            totalAmount: 12.99,
+            status: OrderStatus.DELIVERED,
+          });
+          p.ensureOrder("ca2", {
+            customer: "alice",
+            products: ["cola"],
+            totalAmount: 4.99,
+            status: OrderStatus.PENDING,
+          });
+          p.ensureOrder("cb1", {
+            customer: "bob",
+            products: ["salad"],
+            totalAmount: 8.99,
+            status: OrderStatus.PREPARING,
+          });
+        })
+        .load();
+
+      const customer = s.customer("alice");
 
       return request(app.getHttpServer())
         .get(`/api/orders/customer/${customer.id}`)
         .expect(200)
         .expect((res) => {
           expect(Array.isArray(res.body)).toBe(true);
-          res.body.forEach((order) => {
+          res.body.forEach((order: any) => {
             expect(order.customer.id).toBe(customer.id);
           });
         });
     });
 
-    it("POST / should create a new order", () => {
-      const customer = fixtures.getCustomers()[0];
-      const products = fixtures.getProducts().slice(0, 2);
+    it("POST / should create a new order", async () => {
+      const s = await useScenario(app, "small-catalog").load();
 
       const createOrderDto: CreateOrderDto = {
-        customerId: customer.id,
-        productIds: products.map((p) => p.id),
+        customerId: s.customer("alice").id,
+        productIds: s.ids(["pizza", "cola"]),
         totalAmount: 30.5,
         notes: "Test order notes",
       };
@@ -111,57 +174,81 @@ describe("OrderController (e2e)", () => {
         .expect(201)
         .expect((res) => {
           expect(res.body.status).toBe(OrderStatus.PENDING);
-          expect(res.body.totalAmount).toBe(createOrderDto.totalAmount);
+          expect(parseFloat(res.body.totalAmount)).toBe(
+            createOrderDto.totalAmount
+          );
           expect(res.body.notes).toBe(createOrderDto.notes);
-          expect(res.body.customer.id).toBe(customer.id);
-          expect(res.body.products.length).toBe(products.length);
+          expect(res.body.customer.id).toBe(s.customer("alice").id);
+          expect(res.body.products.length).toBe(2);
         });
     });
 
-    it("PATCH /:id/status should update order status", () => {
-      const order = fixtures
-        .getOrders()
-        .find((o) => o.status === OrderStatus.READY);
+    it("PATCH /:id/status should update order status", async () => {
+      const s = await useScenario(app, "small-catalog")
+        .patch((p) => {
+          p.ensureOrder("readyOrder", {
+            customer: "alice",
+            products: ["pizza"],
+            totalAmount: 12.99,
+            status: OrderStatus.READY,
+          });
+        })
+        .load();
+
+      const orderId = s.order("readyOrder").id;
       const newStatus = OrderStatus.DELIVERED;
 
       return request(app.getHttpServer())
-        .patch(`/api/orders/${order.id}/status`)
+        .patch(`/api/orders/${orderId}/status`)
         .send({ status: newStatus })
         .expect(200)
         .expect((res) => {
-          expect(res.body.id).toBe(order.id);
+          expect(res.body.id).toBe(orderId);
           expect(res.body.status).toBe(newStatus);
         });
     });
 
-    it("PATCH /:id/status should prevent invalid status transitions", () => {
-      const order = fixtures
-        .getOrders()
-        .find((o) => o.status === OrderStatus.DELIVERED);
+    it("PATCH /:id/status should prevent invalid status transitions", async () => {
+      const s = await useScenario(app, "small-catalog")
+        .patch((p) => {
+          p.ensureOrder("deliv", {
+            customer: "alice",
+            products: ["pizza"],
+            totalAmount: 12.99,
+            status: OrderStatus.DELIVERED,
+          });
+        })
+        .load();
+
+      const orderId = s.order("deliv").id;
       const newStatus = OrderStatus.PREPARING;
 
       return request(app.getHttpServer())
-        .patch(`/api/orders/${order.id}/status`)
+        .patch(`/api/orders/${orderId}/status`)
         .send({ status: newStatus })
         .expect(400);
     });
 
-    it("DELETE /:id should cancel an order", () => {
-      const order = fixtures
-        .getOrders()
-        .find(
-          (o) =>
-            o.status === OrderStatus.PENDING ||
-            o.status === OrderStatus.PREPARING
-        );
+    it("DELETE /:id should cancel an order", async () => {
+      const s = await useScenario(app, "small-catalog")
+        .patch((p) => {
+          p.ensureOrder("toCancel", {
+            customer: "alice",
+            products: ["pizza"],
+            totalAmount: 12.99,
+            status: OrderStatus.PENDING,
+          });
+        })
+        .load();
+
+      const orderId = s.order("toCancel").id;
 
       return request(app.getHttpServer())
-        .delete(`/api/orders/${order.id}`)
+        .delete(`/api/orders/${orderId}`)
         .expect(204)
         .then(() => {
-          // Verify order status is cancelled
           return request(app.getHttpServer())
-            .get(`/api/orders/${order.id}`)
+            .get(`/api/orders/${orderId}`)
             .expect(200)
             .expect((res) => {
               expect(res.body.status).toBe(OrderStatus.CANCELLED);


### PR DESCRIPTION
### Etape 1
Help me work on a better, decoupled system for fixtures loading.
I want to be able to load scenarios before each test, and maybe modify general scenarios to match the needs of the test for each test.

Propose first 3 possible interfaces in this discussion, without modifying the files, you would see for the "POST / should create a new order" test in #file:order.e2e-spec.ts (instead of loading global fixtures at the top of the test suite).

Pay close attention to how the relationship between fixtures is implemented. I need to be able to create an order referencing existing products and existing clients for example

Then I will select one and ask you to implement it

### Etape 2
How do you define the scenarios in option 3 ?

### Etape 3 - first commit
Implement this option (option 3) in the #file:order.e2e-spec.ts and of course in #file:global-fixtures.ts . Decouple from the other tests suites

### Etape 4 - second commit
Convert now the other suites, create as many scenarios as you see fit.
Delete what will be unused at the end of your refacto (I am guessing the load() in #sym:GlobalFixtures